### PR TITLE
Added x and y coordinates of particle to properties as property "centroid"

### DIFF
--- a/ParticleSpy/ParticleAnalysis.py
+++ b/ParticleSpy/ParticleAnalysis.py
@@ -85,6 +85,9 @@ def ParticleAnalysis(acquisition,parameters,particles=None,mask=np.zeros((1))):
         diam_units = image.axes_manager[0].units
         p.set_circdiam(cal_circdiam,diam_units)
         
+        #Set particle centroid
+        p.set_property("centroid",region.centroid,"None")
+        
         cal_axes_lengths = (region.major_axis_length*image.axes_manager[0].scale,region.minor_axis_length*image.axes_manager[0].scale)
         #Note: the above only works for square pixels
         p.set_axes_lengths(cal_axes_lengths,diam_units)

--- a/ParticleSpy/ParticleAnalysis.py
+++ b/ParticleSpy/ParticleAnalysis.py
@@ -85,8 +85,9 @@ def ParticleAnalysis(acquisition,parameters,particles=None,mask=np.zeros((1))):
         diam_units = image.axes_manager[0].units
         p.set_circdiam(cal_circdiam,diam_units)
         
-        #Set particle centroid
-        p.set_property("centroid",region.centroid,"None")
+        #Set particle x, y coordinates
+        p.set_property("x",region.centroid[0]*image.axes_manager[0].scale,image.axes_manager[0].units)
+        p.set_property("y",region.centroid[1]*image.axes_manager[1].scale,image.axes_manager[1].units)
         
         cal_axes_lengths = (region.major_axis_length*image.axes_manager[0].scale,region.minor_axis_length*image.axes_manager[0].scale)
         #Note: the above only works for square pixels

--- a/ParticleSpy/tests/test_particle_analysis.py
+++ b/ParticleSpy/tests/test_particle_analysis.py
@@ -108,6 +108,8 @@ def test_particleanalysis():
     eds_particle_spectrum = eds_particle.sum()
     nptest.assert_allclose(p.spectrum['EDS_TEM'].data,eds_particle_spectrum.data)
     nptest.assert_allclose(p.composition['Au'],46.94530019)
+    nptest.assert_allclose(p.properties['centroid']['value'][0], 100.)
+    nptest.assert_allclose(p.properties['centroid']['value'][1], 100.)
     
 def test_normalize_boxing():
     mask = gen_test.generate_test_image2(hspy=False)

--- a/ParticleSpy/tests/test_particle_analysis.py
+++ b/ParticleSpy/tests/test_particle_analysis.py
@@ -108,8 +108,8 @@ def test_particleanalysis():
     eds_particle_spectrum = eds_particle.sum()
     nptest.assert_allclose(p.spectrum['EDS_TEM'].data,eds_particle_spectrum.data)
     nptest.assert_allclose(p.composition['Au'],46.94530019)
-    nptest.assert_allclose(p.properties['centroid']['value'][0], 100.)
-    nptest.assert_allclose(p.properties['centroid']['value'][1], 100.)
+    nptest.assert_allclose(p.properties['x']['value'], 100.)
+    nptest.assert_allclose(p.properties['y']['value'], 100.)
     
 def test_normalize_boxing():
     mask = gen_test.generate_test_image2(hspy=False)

--- a/docs/particle_analysis.rst
+++ b/docs/particle_analysis.rst
@@ -30,6 +30,8 @@ The calculated parameters include:
 
 * Total particle intensity
 
+* Centroid
+
 .. code-block:: python
 
     >>> #Syntax for accessing particle properties.

--- a/docs/particle_analysis.rst
+++ b/docs/particle_analysis.rst
@@ -30,7 +30,7 @@ The calculated parameters include:
 
 * Total particle intensity
 
-* Centroid
+* X and Y coordinates
 
 .. code-block:: python
 


### PR DESCRIPTION
This pull request adds a new property, "centroid", to the automatically determined properties.