### PR TITLE
Add bounding box and associated values to particle properties

### DIFF
--- a/ParticleSpy/ParticleAnalysis.py
+++ b/ParticleSpy/ParticleAnalysis.py
@@ -132,6 +132,12 @@ def ParticleAnalysis(acquisition,parameters,particles=None,mask=np.zeros((1))):
         #Set mask
         p.set_mask(maskp)
         
+        #Set bounding box
+        p.set_boundingbox(region.bbox)
+        p.set_property("bbox_area", region.bbox_area*image.axes_manager[0].scale*image.axes_manager[1].scale, area_units)
+        bbox_length = (((region.bbox[2] - region.bbox[0])*image.axes_manager[0].scale)**2 + ((region.bbox[3] - region.bbox[1])*image.axes_manager[1].scale)**2)**0.5
+        p.set_property("bbox_length", bbox_length, image.axes_manager[0].units)
+        
         p.set_property('frame',None,None)
         
         if parameters.store["store_im"]==True:

--- a/ParticleSpy/ptcl_class.py
+++ b/ParticleSpy/ptcl_class.py
@@ -85,6 +85,9 @@ class Particle(object):
     def set_zone(self, zone):
         self.zone = zone
         
+    def set_boundingbox(self, bbox):
+        self.bbox = bbox
+        
     def set_mask(self, mask):
         self.mask = mask
         

--- a/ParticleSpy/ptcl_class.py
+++ b/ParticleSpy/ptcl_class.py
@@ -118,7 +118,7 @@ class Particle_list(object):
     def save(self,filename):
         save_plist(self,filename)
         
-    def plot(self,prop_list=['area'],bins=20,**kwargs):
+    def plot(self,prop_list=['area'],**kwargs):
         """
         Plots properties of all particles in the Particle_list.
         
@@ -130,8 +130,8 @@ class Particle_list(object):
         ----------
         prop_list : str or list
             A particle property or a list of the names of the properties to plot.
-        bins : int
-            The number of bins in the histogram if plotting one property.
+        **kwargs
+            Keyword arguments for matplotlib plotting functions.
             
         Examples
         --------

--- a/ParticleSpy/tests/test_particle_analysis.py
+++ b/ParticleSpy/tests/test_particle_analysis.py
@@ -110,6 +110,11 @@ def test_particleanalysis():
     nptest.assert_allclose(p.composition['Au'],46.94530019)
     nptest.assert_allclose(p.properties['x']['value'], 100.)
     nptest.assert_allclose(p.properties['y']['value'], 100.)
+    nptest.assert_allclose(p.properties['bbox_area']['value'], 25281.0)
+    nptest.assert_allclose(p.properties['bbox_length']['value'], 224.8599564173221)
+    assert p.properties['bbox_area']['units'] == 'nm^2'
+    assert p.properties['bbox_length']['units'] == 'nm'
+    assert p.bbox == (21, 21, 180, 180)
     
 def test_series():
     image = gen_test.generate_test_image(hspy=True)

--- a/docs/particle_analysis.rst
+++ b/docs/particle_analysis.rst
@@ -18,23 +18,25 @@ Particle Analysis will run the segmentation on your data and calculate a number 
 
 The calculated parameters include:
 
-* Area
+* Area ("area")
 
-* Equivalent circular diameter
+* Equivalent circular diameter ("")
 
-* Major and minor axes lengths
+* Major and minor axes lengths ("major axis length" and "minor axis length")
 
-* Circularity
+* Circularity ("circularity")
 
-* Eccentricity
+* Eccentricity ("eccentricity")
 
-* Solidity
+* Solidity ("solidity")
 
-* Total particle intensity
+* Total particle intensity ("intensity")
 
-* Maximum particle intensity
+* Maximum particle intensity ("intensity_max")
 
-* X and Y coordinates
+* X and Y coordinates ("x" and "y")
+
+* Bounding box area and diagonal length ("bbox_area" and "bbox_length")
 
 
 .. code-block:: python

--- a/docs/plotting_saving.rst
+++ b/docs/plotting_saving.rst
@@ -37,6 +37,8 @@ Plotting of more than one Particle_list can be done using the top level :py:meth
 
     >>> ps.plot([particles1,particles2],['area','circularity'])
 
+All keyword arguments in matplotlib are available by passing them as arguments to the corresponding plotting function.
+
 
 Plotting Radial Profiles
 -----------------------

--- a/docs/properties.rst
+++ b/docs/properties.rst
@@ -34,6 +34,12 @@ When using the :py:meth:`~.ParticleAnalysis` function ParticleSpy is able to cal
     | Total intensity             | intensity                    | The sum of intensity contained within  |
     |                             |                              | the segmented region of the image.     |
     +-----------------------------+------------------------------+----------------------------------------+
+    | Bounding box area           | bbox_area                    | The area of the bounding box           |
+    |                             |                              | surrounding the particle.              |
+    +-----------------------------+------------------------------+----------------------------------------+
+    | Bounding box length         | bbox_length                  | The diagonal length of the bounding    |
+    |                             |                              | box surrounding the particle.          |
+    +-----------------------------+------------------------------+----------------------------------------+
 
 
 Adding Properties


### PR DESCRIPTION
Added the tuple defining a bounding box, the bounding box area and the diagonal length of a bounding box to particle properties.