### PR TITLE
Tweak conda `environment.yml`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,8 @@
 name: pspyenv
 channels:
- - defaults
- - conda-forge
+- conda-forge
 dependencies:
- - hyperspy>=1.7.3
+ - hyperspy-base>=1.7.3
  - exspy
  - scikit-image>=0.17.1
  - scikit-learn>=0.21


### PR DESCRIPTION
- Mixing `defaults` and `conda-forge` should be avoided - they are not binary compatible.
- Use `hyperspy-base` in favour of `hyperspy` to avoid installing unnecessary packages.